### PR TITLE
Change default branch name

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   analyze:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,10 @@ name: Test
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary

Update GitHub Actions workflow configurations to use `main` as the default branch instead of `master`.

## Changes

- Updated `.github/workflows/analyze.yml` to trigger on pushes to `main` branch
- Updated `.github/workflows/test.yml` to trigger on pushes and pull requests targeting `main` branch

## Rationale

This change aligns the workflow configurations with the repository's default branch naming convention, ensuring that CI/CD pipelines run correctly on the primary branch.