### PR TITLE
Fix issue that coverage isn't posted

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,9 +139,6 @@ exclude_also = [
     "raise NotImplementedError",
 ]
 
-[tool.coverage.run]
-source = ["radikoplaylist"]
-
 [tool.docformatter]
 recursive = true
 # For compatibility with Black


### PR DESCRIPTION
## Summary

Removed unused `[tool.coverage.run]` configuration section from `pyproject.toml`.

## Changes

### Configuration Cleanup

- **Removed** `[tool.coverage.run]` section with `source = ["radikoplaylist"]` configuration
- This configuration was only for multiprocessing and it requires special treat to upload