### PR TITLE
Support for Time Free 30

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ time.sleep(3)
 popen.terminate()
 ```
 
-### Record Time Free
+### Record Time Free (7-Day)
 
 ```python
 import ffmpeg
@@ -71,5 +71,34 @@ stream = ffmpeg.output(stream, "./record.m4a", f='mp4', c='copy')
 ffmpeg.run(stream)
 ```
 
+### Record Time Free (30-Day)
+
+For accessing programs within the past 30 days, you need a radiko premium account.
+First, log in to [radiko.jp] in your browser, then get the `radiko_session` cookie value from your browser's developer tools.
+
+```python
+import ffmpeg
+
+from radikoplaylist import MasterPlaylistClient, TimeFree30DayMasterPlaylistRequest
+
+master_playlist_request = TimeFree30DayMasterPlaylistRequest(
+    "802", 20251214220000, 20251214223000
+)
+master_playlist = MasterPlaylistClient.get(
+    master_playlist_request,
+    area_id="JP13",
+    radiko_session="your_radiko_session_value_from_cookie_here"
+)
+
+stream = ffmpeg.input(
+    master_playlist.media_playlist_url,
+    headers=master_playlist.headers,
+    copytb='1'
+)
+stream = ffmpeg.output(stream, "./record.m4a", f='mp4', c='copy')
+ffmpeg.run(stream)
+```
+
 [ffmpeg]: https://trac.ffmpeg.org/wiki/CompilationGuide
 [ffmpeg-python]: https://pypi.org/project/ffmpeg-python/
+[radiko.jp]: https://radiko.jp/

--- a/radikoplaylist/master_playlist_client.py
+++ b/radikoplaylist/master_playlist_client.py
@@ -28,9 +28,17 @@ class MasterPlaylistClient:
         master_playlist_request: MasterPlaylistRequest,
         *,
         area_id: str = Authorization.ARIA_ID_DEFAULT,
+        radiko_session: str | None = None,
     ) -> MasterPlaylist:
-        """Gets master playlist."""
-        headers = Authorization(area_id=area_id).auth()
+        """Gets master playlist.
+
+        Args:
+            master_playlist_request: Request object (Live, TimeFree, or TimeFree30Day)
+            area_id: Area ID for radiko (default: JP13 for Tokyo)
+            radiko_session: Optional radiko premium session cookie for 30-day timefree access.
+                Required for TimeFree30DayMasterPlaylistRequest to access premium content.
+        """
+        headers = Authorization(area_id=area_id, radiko_session=radiko_session).auth()
         url_master_playlist = cls._get_url(master_playlist_request, headers)
         return MasterPlaylist(url_master_playlist, headers)
 

--- a/radikoplaylist/playlist_create_url_getter.py
+++ b/radikoplaylist/playlist_create_url_getter.py
@@ -167,3 +167,27 @@ class TimeFreePlaylistCreateUrlGetter(PlaylistCreateUrlGetter[TimeFreeUrlChecker
         if host.is_fastest_host_to_download(playlist_create_url):
             raise FoundFastestHostToDownload(playlist_create_url)
         return host.is_ffmpeg_supported(playlist_create_url)
+
+
+class TimeFree30DayPlaylistCreateUrlGetter(PlaylistCreateUrlGetter[TimeFreeUrlChecker]):
+    """Implements getting process Time Free 30-day URL to create playlist.
+
+    This URL getter supports radiko's 30-day timefree feature (extended from the standard 7-day window). Uses the same
+    XML filtering as TimeFreePlaylistCreateUrlGetter since the API XML response does not distinguish between 7-day and
+    30-day content. The distinction is made at the query parameter level (type=c vs type=b).
+    """
+
+    @classmethod
+    @abstractmethod
+    def time_free(cls) -> str:
+        return "1"
+
+    @classmethod
+    def create_host(cls) -> TimeFreeUrlChecker:
+        return TimeFreeUrlChecker()
+
+    @classmethod
+    def filter_url(cls, playlist_create_url: str, host: TimeFreeUrlChecker) -> bool:
+        if host.is_fastest_host_to_download(playlist_create_url):
+            raise FoundFastestHostToDownload(playlist_create_url)
+        return host.is_ffmpeg_supported(playlist_create_url)

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -23,3 +23,13 @@ class TestAuthorization:
         authorization = Authorization()
         with pytest.raises(BadHttpStatusCodeError):
             authorization.auth()
+
+    @staticmethod
+    @pytest.mark.usefixtures("mock_auth_1", "mock_auth_2")
+    def test_with_radiko_session() -> None:
+        """Test that radiko_session cookie is added to headers."""
+        radiko_session = "test_session_value_123"
+        authorization = Authorization(radiko_session=radiko_session)
+        headers = authorization.auth()
+        assert "Cookie" in headers
+        assert headers["Cookie"] == f"radiko_session={radiko_session}"

--- a/tests/test_master_playlist_request.py
+++ b/tests/test_master_playlist_request.py
@@ -6,10 +6,12 @@ from urllib.parse import urlparse
 import pytest
 
 from radikoplaylist.master_playlist_request import LiveMasterPlaylistRequest
+from radikoplaylist.master_playlist_request import TimeFree30DayMasterPlaylistRequest
 from radikoplaylist.master_playlist_request import TimeFreeMasterPlaylistRequest
 from tests.testlibraries.expected_url import ExpectedUrl
 from tests.testlibraries.instance_resource import InstanceResource
 from tests.testlibraries.instance_resource import ParameterExpectedLiveUrl
+from tests.testlibraries.instance_resource import ParameterExpectedTimeFree30DayUrl
 from tests.testlibraries.instance_resource import ParameterExpectedTimeFreeUrl
 
 
@@ -58,3 +60,28 @@ class TestMasterPlaylistRequest:
     @staticmethod
     def test_generate_uid() -> None:
         assert re.match(r"^[a-fA-F0-9]{32}$", TimeFreeMasterPlaylistRequest.generate_uid())
+
+    @staticmethod
+    @pytest.mark.usefixtures("mock_get_playlist_create_url")
+    @pytest.mark.parametrize(
+        ("mock_get_playlist_create_url", "station", "expected_url"),
+        InstanceResource.concat(
+            InstanceResource.LIST_STATION,
+            InstanceResource.LIST_STATION,
+            ParameterExpectedTimeFree30DayUrl.to_list(),
+        ),
+        indirect=["mock_get_playlist_create_url"],
+    )
+    # pylint: disable=unused-argument
+    def test_build_time_free_30day_master_playlist_url(station: str, expected_url: ExpectedUrl) -> None:
+        """Method build_url() should build appropriate URL with type=c for 30-day timefree."""
+        date_time_start = 20200518215700
+        date_time_end = 20200518220000
+        playlist_request = TimeFree30DayMasterPlaylistRequest(station, date_time_start, date_time_end)
+        url = playlist_request.build_url(InstanceResource.HEADERS_EXAMPLE)
+        parse_result_url = urlparse(url)
+        expected_url.check(parse_result_url)
+
+    @staticmethod
+    def test_generate_uid_30day() -> None:
+        assert re.match(r"^[a-fA-F0-9]{32}$", TimeFree30DayMasterPlaylistRequest.generate_uid())

--- a/tests/test_playlist_create_url_getter.py
+++ b/tests/test_playlist_create_url_getter.py
@@ -6,6 +6,7 @@ import pytest
 from defusedxml import ElementTree
 
 from radikoplaylist.playlist_create_url_getter import LivePlaylistCreateUrlGetter
+from radikoplaylist.playlist_create_url_getter import TimeFree30DayPlaylistCreateUrlGetter
 from radikoplaylist.playlist_create_url_getter import TimeFreePlaylistCreateUrlGetter
 from tests.testlibraries.instance_resource import InstanceResource
 from tests.testlibraries.instance_resource import ParameterExpectedLivePlaylistCreateUrlString
@@ -41,6 +42,17 @@ class TestPlaylistCreateUrlGetter:
     def test_time_free(xml_playlist_create_url: str) -> None:
         """Method get_playlist_create_url should return appropriate URL."""
         url = TimeFreePlaylistCreateUrlGetter.get_playlist_create_url(xml_playlist_create_url)
+        assert url == "https://radiko.jp/v2/api/ts/playlist.m3u8"
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "xml_playlist_create_url",
+        InstanceResource.LIST_STATION,
+        indirect=["xml_playlist_create_url"],
+    )
+    def test_time_free_30day(xml_playlist_create_url: str) -> None:
+        """Method get_playlist_create_url should return appropriate URL for 30-day timefree."""
+        url = TimeFree30DayPlaylistCreateUrlGetter.get_playlist_create_url(xml_playlist_create_url)
         assert url == "https://radiko.jp/v2/api/ts/playlist.m3u8"
 
     def test_strip_playlist_create_url(self) -> None:

--- a/tests/testlibraries/instance_resource.py
+++ b/tests/testlibraries/instance_resource.py
@@ -621,3 +621,248 @@ class ParameterExpectedTimeFreeUrl(ParameterList):
             "lsid": InstanceResource.PATTERN_LSID_TIME_FREE_MASTER_PLAYLIST,
         },
     )
+
+
+class ParameterExpectedTimeFree30DayUrl(ParameterList):
+    """To use for parametrized test for 30-day timefree."""
+
+    BAYFM78 = ExpectedUrl(
+        ExpectedUrlProperties(
+            "https",
+            "radiko.jp",
+            "/v2/api/ts/playlist.m3u8",
+            "",
+            "",
+        ),
+        {
+            "l": "15",
+            "station_id": "BAYFM78",
+            "type": "c",
+            "lsid": InstanceResource.PATTERN_LSID_TIME_FREE_MASTER_PLAYLIST,
+        },
+    )
+    FMJ = ExpectedUrl(
+        ExpectedUrlProperties(
+            "https",
+            "radiko.jp",
+            "/v2/api/ts/playlist.m3u8",
+            "",
+            "",
+        ),
+        {
+            "l": "15",
+            "station_id": "FMJ",
+            "type": "c",
+            "lsid": InstanceResource.PATTERN_LSID_TIME_FREE_MASTER_PLAYLIST,
+        },
+    )
+    FMR = ExpectedUrl(
+        ExpectedUrlProperties(
+            "https",
+            "radiko.jp",
+            "/v2/api/ts/playlist.m3u8",
+            "",
+            "",
+        ),
+        {
+            "l": "15",
+            "station_id": "FMR",
+            "type": "c",
+            "lsid": InstanceResource.PATTERN_LSID_TIME_FREE_MASTER_PLAYLIST,
+        },
+    )
+    FMT = ExpectedUrl(
+        ExpectedUrlProperties(
+            "https",
+            "radiko.jp",
+            "/v2/api/ts/playlist.m3u8",
+            "",
+            "",
+        ),
+        {
+            "l": "15",
+            "station_id": "FMT",
+            "type": "c",
+            "lsid": InstanceResource.PATTERN_LSID_TIME_FREE_MASTER_PLAYLIST,
+        },
+    )
+    HOUSOU_DAIGAKU = ExpectedUrl(
+        ExpectedUrlProperties(
+            "https",
+            "radiko.jp",
+            "/v2/api/ts/playlist.m3u8",
+            "",
+            "",
+        ),
+        {
+            "l": "15",
+            "station_id": "HOUSOU-DAIGAKU",
+            "type": "c",
+            "lsid": InstanceResource.PATTERN_LSID_TIME_FREE_MASTER_PLAYLIST,
+        },
+    )
+    INT = ExpectedUrl(
+        ExpectedUrlProperties(
+            "https",
+            "radiko.jp",
+            "/v2/api/ts/playlist.m3u8",
+            "",
+            "",
+        ),
+        {
+            "l": "15",
+            "station_id": "INT",
+            "type": "c",
+            "lsid": InstanceResource.PATTERN_LSID_TIME_FREE_MASTER_PLAYLIST,
+        },
+    )
+    JOAK = ExpectedUrl(
+        ExpectedUrlProperties(
+            "https",
+            "radiko.jp",
+            "/v2/api/ts/playlist.m3u8",
+            "",
+            "",
+        ),
+        {
+            "l": "15",
+            "station_id": "JOAK",
+            "type": "c",
+            "lsid": InstanceResource.PATTERN_LSID_TIME_FREE_MASTER_PLAYLIST,
+        },
+    )
+    JOAK_FM = ExpectedUrl(
+        ExpectedUrlProperties(
+            "https",
+            "radiko.jp",
+            "/v2/api/ts/playlist.m3u8",
+            "",
+            "",
+        ),
+        {
+            "l": "15",
+            "station_id": "JOAK-FM",
+            "type": "c",
+            "lsid": InstanceResource.PATTERN_LSID_TIME_FREE_MASTER_PLAYLIST,
+        },
+    )
+    JORF = ExpectedUrl(
+        ExpectedUrlProperties(
+            "https",
+            "radiko.jp",
+            "/v2/api/ts/playlist.m3u8",
+            "",
+            "",
+        ),
+        {
+            "l": "15",
+            "station_id": "JORF",
+            "type": "c",
+            "lsid": InstanceResource.PATTERN_LSID_TIME_FREE_MASTER_PLAYLIST,
+        },
+    )
+    LFR = ExpectedUrl(
+        ExpectedUrlProperties(
+            "https",
+            "radiko.jp",
+            "/v2/api/ts/playlist.m3u8",
+            "",
+            "",
+        ),
+        {
+            "l": "15",
+            "station_id": "LFR",
+            "type": "c",
+            "lsid": InstanceResource.PATTERN_LSID_TIME_FREE_MASTER_PLAYLIST,
+        },
+    )
+    NACK5 = ExpectedUrl(
+        ExpectedUrlProperties(
+            "https",
+            "radiko.jp",
+            "/v2/api/ts/playlist.m3u8",
+            "",
+            "",
+        ),
+        {
+            "l": "15",
+            "station_id": "NACK5",
+            "type": "c",
+            "lsid": InstanceResource.PATTERN_LSID_TIME_FREE_MASTER_PLAYLIST,
+        },
+    )
+    QRR = ExpectedUrl(
+        ExpectedUrlProperties(
+            "https",
+            "radiko.jp",
+            "/v2/api/ts/playlist.m3u8",
+            "",
+            "",
+        ),
+        {
+            "l": "15",
+            "station_id": "QRR",
+            "type": "c",
+            "lsid": InstanceResource.PATTERN_LSID_TIME_FREE_MASTER_PLAYLIST,
+        },
+    )
+    RN1 = ExpectedUrl(
+        ExpectedUrlProperties(
+            "https",
+            "radiko.jp",
+            "/v2/api/ts/playlist.m3u8",
+            "",
+            "",
+        ),
+        {
+            "l": "15",
+            "station_id": "RN1",
+            "type": "c",
+            "lsid": InstanceResource.PATTERN_LSID_TIME_FREE_MASTER_PLAYLIST,
+        },
+    )
+    RN2 = ExpectedUrl(
+        ExpectedUrlProperties(
+            "https",
+            "radiko.jp",
+            "/v2/api/ts/playlist.m3u8",
+            "",
+            "",
+        ),
+        {
+            "l": "15",
+            "station_id": "RN2",
+            "type": "c",
+            "lsid": InstanceResource.PATTERN_LSID_TIME_FREE_MASTER_PLAYLIST,
+        },
+    )
+    TBS = ExpectedUrl(
+        ExpectedUrlProperties(
+            "https",
+            "radiko.jp",
+            "/v2/api/ts/playlist.m3u8",
+            "",
+            "",
+        ),
+        {
+            "l": "15",
+            "station_id": "TBS",
+            "type": "c",
+            "lsid": InstanceResource.PATTERN_LSID_TIME_FREE_MASTER_PLAYLIST,
+        },
+    )
+    YFM = ExpectedUrl(
+        ExpectedUrlProperties(
+            "https",
+            "radiko.jp",
+            "/v2/api/ts/playlist.m3u8",
+            "",
+            "",
+        ),
+        {
+            "l": "15",
+            "station_id": "YFM",
+            "type": "c",
+            "lsid": InstanceResource.PATTERN_LSID_TIME_FREE_MASTER_PLAYLIST,
+        },
+    )


### PR DESCRIPTION
## Summary

This PR adds support for radiko's **30-day timefree** feature, enabling access to recorded programs within the past 30 days (extended from the standard 7-day window). This requires a radiko premium account session cookie and implements the necessary authentication flow to support premium features.

### Key Changes

- ✨ **New request type**: `TimeFree30DayMasterPlaylistRequest` for accessing 30-day timefree content
- 🔐 **Premium authentication**: Added `radiko_session` parameter support throughout the authentication chain
- 📚 **Documentation**: Updated README and CLAUDE.md with 30-day timefree usage examples
- ✅ **Test coverage**: Achieved 100% test coverage (was 99%, now 100%)

## Changes by Component

### Core Library

#### `Authorization` ([authorization.py](radikoplaylist/authorization.py))
- Added optional `radiko_session` parameter to `__init__()` for premium account cookie
- Updated `auth()` method to include `Cookie` header when `radiko_session` is provided
- Maintains standard auth1/auth2 flow for both free and premium accounts

#### `MasterPlaylistClient` ([master_playlist_client.py](radikoplaylist/master_playlist_client.py))
- Added `radiko_session` parameter to `get()` method
- Passes session cookie through to `Authorization` for premium features
- Updated docstrings with parameter descriptions

#### `MasterPlaylistRequest` ([master_playlist_request.py](radikoplaylist/master_playlist_request.py))
- **New class**: `TimeFree30DayMasterPlaylistRequest`
  - Same signature as `TimeFreeMasterPlaylistRequest` (station_id, start_at, end_at)
  - Uses `type=c` query parameter instead of `type=b` to signal 30-day access
  - Generates MD5-based UID consistent with radiko's JavaScript implementation
- Added to `__all__` exports

#### `PlaylistCreateUrlGetter` ([playlist_create_url_getter.py](radikoplaylist/playlist_create_url_getter.py))
- **New class**: `TimeFree30DayPlaylistCreateUrlGetter`
  - Uses same XML filtering as 7-day variant (`timefree='1'`)
  - Prioritizes `radiko.jp` hosts for optimal download speed
  - Filters out FFmpeg-incompatible CDN hosts

### Documentation

#### [README.md](README.md)
- Clarified existing "Record Time Free" section as "Record Time Free (7-Day)"
- Added new "Record Time Free (30-Day)" section with:
  - Premium account requirements
  - Step-by-step authentication instructions
  - Complete code example using `TimeFree30DayMasterPlaylistRequest`

#### [CLAUDE.md](CLAUDE.md)
- Updated architecture documentation to reflect three request types
- Added "Premium Account Authentication (30-Day Timefree)" section
- Documented the distinction between 7-day (`type=b`) and 30-day (`type=c`) access
- Clarified that both variants use the same XML filtering logic

### Tests

#### [test_authorization.py](tests/test_authorization.py)
- **New test**: `test_with_radiko_session()` - validates cookie header is properly set
- This test covers the previously uncovered lines and achieves **100% coverage**

#### [test_master_playlist_request.py](tests/test_master_playlist_request.py)
- **New test**: `test_build_time_free_30day_master_playlist_url()` - validates URL generation with `type=c`
- **New test**: `test_generate_uid_30day()` - validates UID format

#### [test_playlist_create_url_getter.py](tests/test_playlist_create_url_getter.py)
- **New test**: `test_time_free_30day()` - validates playlist URL retrieval for 30-day timefree

#### [instance_resource.py](tests/testlibraries/instance_resource.py)
- **New test resource class**: `ParameterExpectedTimeFree30DayUrl`
- Defines expected URL patterns for all 16 test stations with `type=c` parameter

## Technical Details

### Authentication Flow

The library maintains backward compatibility while adding premium support:

1. **Standard flow** (no `radiko_session`): Uses existing auth1/auth2 flow → 7-day timefree access
2. **Premium flow** (with `radiko_session`): Performs auth1/auth2 flow + adds session cookie → 30-day timefree access

### API Distinctions

| Feature | 7-Day Timefree | 30-Day Timefree |
|---------|---------------|-----------------|
| Query param | `type=b` | `type=c` |
| XML filtering | `timefree='1'` | `timefree='1'` (same) |
| Authentication | Standard auth1/auth2 | auth1/auth2 + session cookie |
| Account requirement | Free account | Premium account |

## Test Coverage

TOTAL 293 0 100%


All 137 tests passing with 100% code coverage achieved.

## Usage Example

```python
from radikoplaylist import MasterPlaylistClient, TimeFree30DayMasterPlaylistRequest
import ffmpeg

# Create 30-day timefree request
request = TimeFree30DayMasterPlaylistRequest(
    station_id="JOAK",
    start_at=20251214220000,  # YYYYMMDDHHmmss
    end_at=20251214223000
)

# Get playlist with premium session cookie
playlist = MasterPlaylistClient.get(
    request,
    area_id="JP13",
    radiko_session="your_radiko_session_cookie_from_browser"
)

# Record with FFmpeg
stream = ffmpeg.input(playlist.media_playlist_url, headers=playlist.headers)
stream = ffmpeg.output(stream, "./record.m4a", f='mp4', c='copy')
ffmpeg.run(stream)
```

## Breaking Changes
None. This is a backward-compatible addition. All existing code continues to work without modification.