### PR TITLE
Python 3 14

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -21,6 +21,7 @@ services:
       # Update this to wherever you want VS Code to mount the folder of your project
       - .:/workspace:cached
       - /workspace/.venv
+      - ~/.claude:/root/.claude:cached
 
       # Uncomment the next line to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker-compose for details.
       # - /var/run/docker.sock:/var/run/docker.sock 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,14 +19,20 @@ on:
   schedule:
     - cron: '38 5 * * 2'
 
+permissions:
+  # required for all workflows
+  security-events: write
+  # required to fetch internal or private CodeQL packs
+  packages: read
+  # only required for workflows in private repositories
+  actions: read
+  contents: read
+
 jobs:
   call-workflow:
+    uses: yukihiko-shinoda/reusable-workflow-codeql-python/.github/workflows/workflow.yml@ca5a2fbce666756cb15aca6e3a33852588728909  # v1.0.0
     permissions:
-      # required for all workflows
       security-events: write
-      # required to fetch internal or private CodeQL packs
       packages: read
-      # only required for workflows in private repositories
       actions: read
       contents: read
-    uses: yukihiko-shinoda/invoke-lint/.github/workflows/reusable-codeql-analysis.yml@main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,10 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+permissions:
+  contents: read
 jobs:
   call-workflow:
-    uses: yukihiko-shinoda/invoke-lint/.github/workflows/reusable-deploy.yml@main
+    uses: yukihiko-shinoda/reusable-workflow-invoke-lint-deploy/.github/workflows/workflow.yml@eab497a87ebe0cc07a02f723660b750be925f4aa  # v1.0.0
     secrets:
       pypi_password: ${{ secrets.pypi_password }}

--- a/.github/workflows/qlty.yml
+++ b/.github/workflows/qlty.yml
@@ -2,9 +2,15 @@ on:
   push:
     branches:
       - main
+# For OIDC token exchange with Qlty:
+# - Configuring OpenID Connect in cloud providers - GitHub Docs
+#   https://docs.github.com/en/actions/how-tos/secure-your-work/security-harden-deployments/oidc-in-cloud-providers#adding-permissions-settings
+permissions:
+  contents: read
+  id-token: write
 jobs:
   call-workflow:
+    uses: yukihiko-shinoda/reusable-workflow-invoke-lint-qlty/.github/workflows/workflow.yml@732676e4d8cea832b97f2f66ee73fd65fa837e7d  # v1.0.0
     permissions:
       contents: read
       id-token: write
-    uses: yukihiko-shinoda/invoke-lint/.github/workflows/reusable-qlty.yml@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,11 +6,13 @@ on:
   pull_request:
     branches:
       - main
+permissions:
+  contents: read
 jobs:
   call-workflow-test:
-    uses: yukihiko-shinoda/invoke-lint/.github/workflows/reusable-test.yml@main
+    uses: yukihiko-shinoda/reusable-workflow-invoke-lint-test/.github/workflows/workflow.yml@3deca6708b4c2b623c7eac175a63973c05c64e3b  # v1.0.0
     with:
-      support-python-versions: "[ '3.13', '3.12', '3.11', '3.10', '3.9', '3.8' ]"
+      support-python-versions: "[ '3.14', '3.13', '3.12', '3.11', '3.10', '3.9', '3.8' ]"
       is-supporting-python-3-7-in-linux: true
   call-workflow-lint:
-    uses: yukihiko-shinoda/invoke-lint/.github/workflows/reusable-lint.yml@main
+    uses: yukihiko-shinoda/reusable-workflow-invoke-lint-lint/.github/workflows/workflow.yml@0966c64de69c044585bbdca96980a8393c761829  # v1.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 # Slim image can't install numpy
-FROM futureys/claude-code-python-development:20251104123000
+FROM futureys/claude-code-python-development:20260609002000
 COPY pyproject.toml /workspace/
-RUN uv sync --python 3.13
-COPY . /workspace/
 RUN uv sync
+COPY . /workspace/
 ENTRYPOINT [ "uv", "run" ]
 CMD ["pytest"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ classifiers=[
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Internet",
   "Topic :: Internet :: WWW/HTTP",
   "Typing :: Typed"
@@ -57,6 +58,31 @@ dev = [
   "pyvelocity;python_version>='3.9'",
   # To mock requests to prevent slow test
   "requests-mock",
+  # To prevent following error when uv lock:
+  #   × Failed to build `semgrep==0.86.3`
+  # ├─▶ The build backend returned an error
+  # ╰─▶ Call to `setuptools.build_meta:__legacy__.build_wheel` failed (exit status: 1)
+
+  #     [stderr]
+  #     Traceback (most recent call last):
+  #       File "<string>", line 14, in <module>
+  #         requires = get_requires_for_build({})
+  #       File "/root/.cache/uv/builds-v0/.tmpYdUb3N/lib/python3.14/site-packages/setuptools/build_meta.py", line 333, in get_requires_for_build_wheel
+  #         return self._get_build_requires(config_settings, requirements=[])
+  #                ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  #       File "/root/.cache/uv/builds-v0/.tmpYdUb3N/lib/python3.14/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
+  #         self.run_setup()
+  #         ~~~~~~~~~~~~~~^^
+  #       File "/root/.cache/uv/builds-v0/.tmpYdUb3N/lib/python3.14/site-packages/setuptools/build_meta.py", line 520, in run_setup
+  #         super().run_setup(setup_script=setup_script)
+  #         ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  #       File "/root/.cache/uv/builds-v0/.tmpYdUb3N/lib/python3.14/site-packages/setuptools/build_meta.py", line 317, in run_setup
+  #         exec(code, locals())
+  #         ~~~~^^^^^^^^^^^^^^^^
+  #       File "<string>", line 94, in <module>
+  #       File "<string>", line 72, in find_executable
+  #     Exception: Could not find 'semgrep-core' executable, tried 'SEMGREP_CORE_BIN' and system 'semgrep-core'
+  "semgrep>=0.87.0",
   "types-defusedxml;python_version>='3.8'",
   "types-requests",
   "types-setuptools>=68.2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,57 +50,16 @@ classifiers=[
 
 [dependency-groups]
 dev = [
-  "bandit",
-  "build",
   "bump-my-version",
-  "cohesion",
-  # The coverage==3.5.3 is difficult to analyze its dependencies by dependencies management tool,
-  # so we should avoid 3.5.3 or lower.
-  # - Command: "pipenv install --skip-lock" fails 
-  #   since it tries to parse legacy package metadata and raise InstallError
-  #   · Issue #5595 · pypa/pipenv
-  #   https://github.com/pypa/pipenv/issues/5595
-  "coverage>=3.5.4",
-  # The dlint less than 0.14.0 limits max version of flake8.
-  # - dlint/requirements.txt at 0.13.0 · dlint-py/dlint
-  #   https://github.com/dlint-py/dlint/blob/0.13.0/requirements.txt#L1
-  "dlint>=0.14.0",
-  # To the docformatter load pyproject.toml settings:
-  "docformatter[tomli]; python_version < '3.11'",
-  "docformatter; python_version >= '3.11'",
-  "dodgy",
-  # The hacking depends flake8 ~=6.1.0 or ~=5.0.1 or ~=4.0.1.
-  # We should avoid the versions that is not compatible with the hacking,
-  # considering the speed of dependency calculation process
-  "flake8!=6.0.0,!=5.0.0,>=4.0.1",
-  # To replace E501 in pycodestyle with B950 in flake8-bugbear:
-  # - Using Black with other tools - Black 25.1.0 documentation
-  #   https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#bugbear
-  "flake8-bugbear",
-  # To use flake8 --radon-show-closures
-  "flake8-polyfill",
-  # To use pyproject.toml for Flake8 configuration
-  "Flake8-pyproject",
-  # Latest hacking depends on legacy version of flake8, and legacy hacking doesn't narrow flake8 version.
-  # When unpin hacking, it has possibility to install too legacy version of hacking.
-  "hacking >=5.0.0;python_version>='3.8'",
-  "invokelint>=0.8.1",
-  "mypy",
+  "invokelint[basic]>=0.19.0",
   "numpy",
-  "pylint",
-  "pytest",
   "pytest-resource-path",
   "pyvelocity;python_version>='3.9'",
-  "radon",
   # To mock requests to prevent slow test
   "requests-mock",
-  "ruff>=0.0.17",
-  "semgrep;python_version>='3.9' or platform_system=='Linux'",
   "types-defusedxml;python_version>='3.8'",
-  "types-invoke",
   "types-requests",
   "types-setuptools>=68.2.0.0",
-  "xenon",
 ]
 
 [project.urls]
@@ -129,14 +88,14 @@ replace = '__version__ = "{new_version}"'
 
 [tool.coverage.report]
 exclude_also = [
-    # Assume `if TYPE_CHECKING: ... else: ...` block is covered · Issue #831 · nedbat/coveragepy
-    #   https://github.com/nedbat/coveragepy/issues/831#issuecomment-517778185
-    "if TYPE_CHECKING:",
-    # Pylint will detect instead:
-    # - abstract-method / W0223 - Pylint 2.17.0-dev0 documentation
-    #   https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/abstract-method.html
-    "raise AssertionError",
-    "raise NotImplementedError",
+  # Assume `if TYPE_CHECKING: ... else: ...` block is covered · Issue #831 · nedbat/coveragepy
+  #   https://github.com/nedbat/coveragepy/issues/831#issuecomment-517778185
+  "if TYPE_CHECKING:",
+  # Pylint will detect instead:
+  # - abstract-method / W0223 - Pylint 2.17.0-dev0 documentation
+  #   https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/abstract-method.html
+  "raise AssertionError",
+  "raise NotImplementedError",
 ]
 
 [tool.docformatter]
@@ -177,6 +136,12 @@ strict = true
 module = "m3u8"
 ignore_missing_imports = true
 
+[tool.pylint]
+disable = [
+  # We check line length by flake8-bugbear B950.
+  "line-too-long",
+]
+
 [tool.pylint.basic]
 docstring-min-length = "7"
 
@@ -191,42 +156,47 @@ min-public-methods = "1"
 
 [tool.pytest.ini_options]
 markers = [
-    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+  "slow: marks tests as slow (deselect with '-m \"not slow\"')",
 ]
 # log_cli = true
 # log_cli_level = "DEBUG"
 # log_format = "%(asctime)s %(process)d %(levelname)s %(name)s:%(filename)s:%(lineno)d %(message)s"
 
-[tool.radon]
-cc_min = "B"
-show_complexity = true
-show_mi = true
-
 [tool.ruff]
 line-length = 119
 
 [tool.ruff.lint]
-select = ["ALL"]
+external = [
+  "DUO",  # dlint
+  "H",    # Openstack/hacking
+]
+select = [
+  "ALL",
+  # Since compatible with PEP257, we can check docstring style by Ruff and don't need to consider about docstring style separately:
+  # - Should the first line of a Python function docstring be in imperative mood? (ruff / pydocstyle D401)
+  #   https://zenn.dev/y_shinoda/articles/pydocstyle-d401
+  "D401",    # First line should be in imperative mood
+]
 ignore = [
-    # lint.pydocstyle
-    # Reason: Docstring may be missed since docstring-min-length is set.
-    "D101",    # Missing docstring in public class
-    "D102",    # Missing docstring in public method
-    "D103",    # Missing docstring in public function
-    "D105",    # Missing docstring in magic method
-    "D106",    # Missing docstring in public nested class
-    "D107",    # Missing docstring in __init__
-    # Reason: First line may ends with function signature for expression.
-    "D402",    # First line should not be the function’s “signature”
-    # Reason: First line may ends with ":" for expression.
-    "D415",    # First line should end with a period, question mark, or exclamation point
-    # Reason: `Line too long` is checked by flake8-bugbear.
-    "E501",    # Line too long ({width} > {limit})
+  # lint.pydocstyle
+  # Reason: Docstring may be missed since docstring-min-length is set.
+  "D101",    # Missing docstring in public class
+  "D102",    # Missing docstring in public method
+  "D103",    # Missing docstring in public function
+  "D105",    # Missing docstring in magic method
+  "D106",    # Missing docstring in public nested class
+  "D107",    # Missing docstring in __init__
+  # Reason: First line may ends with function signature for expression.
+  "D402",    # First line should not be the function’s “signature”
+  # Reason: First line may ends with ":" for expression.
+  "D415",    # First line should end with a period, question mark, or exclamation point
+  # Reason: `Line too long` is checked by flake8-bugbear.
+  "E501",    # Line too long ({width} > {limit})
 ]
 unfixable = [
-    # When fix `return a and b != ""` as `return a and b`, mypy will report warning:
-    #   error: Incompatible return value type (got "Union[Literal[False], str]", expected "bool")  [return-value]
-    "PLC1901",
+  # When fix `return a and b != ""` as `return a and b`, mypy will report warning:
+  #   error: Incompatible return value type (got "Union[Literal[False], str]", expected "bool")  [return-value]
+  "PLC1901",
 ]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,8 +82,14 @@ dev = [
   #       File "<string>", line 94, in <module>
   #       File "<string>", line 72, in find_executable
   #     Exception: Could not find 'semgrep-core' executable, tried 'SEMGREP_CORE_BIN' and system 'semgrep-core'
-  "semgrep>=0.87.0",
-  "types-defusedxml;python_version>='3.8'",
+  # If we simply lock as "semgrep; python_version >= '3.9' or python_version>='3.6' and platform_system=='Linux'",
+  # the semgrep 1.121.0 is installed in Python 3.14 and cause following error:
+  #     File "/root/.local/share/uv/python/cpython-3.14.5-linux-aarch64-gnu/lib/python3.14/importlib/__init__.py", line 88, in import_module
+  #       return _bootstrap._gcd_import(name[level:], package, level)
+  #              ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  #   TypeError: Metaclasses with custom tp_new are not supported.
+  "semgrep>=0.87.0; python_version >= '3.9' and python_version < '3.10' or python_version>='3.6' and platform_system=='Linux'",
+  "semgrep>=1.122.0; python_version >= '3.10'",  "types-defusedxml;python_version>='3.8'",
   "types-requests",
   "types-setuptools>=68.2.0.0",
 ]

--- a/radikoplaylist/authorization.py
+++ b/radikoplaylist/authorization.py
@@ -46,7 +46,7 @@ class Authorization:
         self.logger = getLogger(__name__)
 
     def auth(self) -> dict[str, str | bytes]:
-        """Authorizes radiko API and returns authorized HTTP headers.
+        """Authorize radiko API and return authorized HTTP headers.
 
         If radiko_session is provided, adds premium account cookie to the headers in addition to performing the
         standard auth1/auth2 flow.
@@ -77,7 +77,7 @@ class Authorization:
 
     @staticmethod
     def _get_partial_key(response: Response) -> bytes:
-        """Gets partial key for authorize from HTTP response.
+        """Get partial key for authorize from HTTP response.
 
         Algorithm is based on function createPartialkey() in following URL.
 

--- a/radikoplaylist/authorization.py
+++ b/radikoplaylist/authorization.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import base64
 from logging import getLogger
 from typing import TYPE_CHECKING
-from typing import MutableMapping
 
 from radikoplaylist.requester import Requester
 
 if TYPE_CHECKING:
+    from collections.abc import MutableMapping
+
     from requests import Response
 
 

--- a/radikoplaylist/exceptions.py
+++ b/radikoplaylist/exceptions.py
@@ -1,5 +1,9 @@
 """This module implements exceptions for this package."""
 
+# This command prevents docformatter from removing blank lines in docstring against PEP8 (conflicts with Ruff (Black))
+# - The docformatter removes blank line against PEP8 (conflicts with Ruff (Black)) · Issue #350 · PyCQA/docformatter
+#   https://github.com/PyCQA/docformatter/issues/350
+
 
 class Error(Exception):
     """Base class for exceptions in this module.

--- a/radikoplaylist/master_playlist.py
+++ b/radikoplaylist/master_playlist.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Mapping
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 
 # pylint: disable=too-few-public-methods

--- a/radikoplaylist/master_playlist_client.py
+++ b/radikoplaylist/master_playlist_client.py
@@ -30,7 +30,7 @@ class MasterPlaylistClient:
         area_id: str = Authorization.ARIA_ID_DEFAULT,
         radiko_session: str | None = None,
     ) -> MasterPlaylist:
-        """Gets master playlist.
+        """Get master playlist.
 
         Args:
             master_playlist_request: Request object (Live, TimeFree, or TimeFree30Day)
@@ -44,7 +44,6 @@ class MasterPlaylistClient:
 
     @classmethod
     def _get_url(cls, master_playlist_request: MasterPlaylistRequest, headers: Mapping[str, str | bytes]) -> str:
-        """Gets URL of master playlist."""
         logger = getLogger(__name__)
         response = Requester.get(master_playlist_request.build_url(headers), headers)
         master_playlist_url = m3u8.loads(response.content.decode("utf-8")).playlists[0].uri

--- a/radikoplaylist/master_playlist_client.py
+++ b/radikoplaylist/master_playlist_client.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from logging import getLogger
 from typing import TYPE_CHECKING
-from typing import Mapping
 from typing import cast
 
 import m3u8
@@ -14,6 +13,8 @@ from radikoplaylist.master_playlist import MasterPlaylist
 from radikoplaylist.requester import Requester
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from radikoplaylist.master_playlist_request import MasterPlaylistRequest
 
 __all__ = ["MasterPlaylistClient"]

--- a/radikoplaylist/master_playlist_request.py
+++ b/radikoplaylist/master_playlist_request.py
@@ -8,11 +8,14 @@ from abc import ABC
 from abc import abstractmethod
 from logging import getLogger
 from random import SystemRandom
-from typing import Mapping
+from typing import TYPE_CHECKING
 
 from radikoplaylist.playlist_create_url_getter import LivePlaylistCreateUrlGetter
 from radikoplaylist.playlist_create_url_getter import TimeFree30DayPlaylistCreateUrlGetter
 from radikoplaylist.playlist_create_url_getter import TimeFreePlaylistCreateUrlGetter
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 __all__ = [
     "LiveMasterPlaylistRequest",

--- a/radikoplaylist/master_playlist_request.py
+++ b/radikoplaylist/master_playlist_request.py
@@ -32,7 +32,6 @@ class MasterPlaylistRequest(ABC):
         self.logger = getLogger(__name__)
 
     def build_url(self, headers: Mapping[str, str | bytes]) -> str:
-        """Creates URL of master playlist."""
         url = self.get_playlist_create_url(headers) + "?" + self.build_query()
         self.logger.debug("playlist url:%s", url)
         return url

--- a/radikoplaylist/master_playlist_request.py
+++ b/radikoplaylist/master_playlist_request.py
@@ -101,9 +101,12 @@ class TimeFreeMasterPlaylistRequest(MasterPlaylistRequest):
         now = datetime.datetime.now(tz=TimeFreeMasterPlaylistRequest.JST)
         start = datetime.datetime(1970, 1, 1, tzinfo=TimeFreeMasterPlaylistRequest.JST)
         micro_second = datetime.timedelta.total_seconds(now - start) * 1000
-        # Reason: 2023-02-06 Javascript in radiko.jp still use MD5_hexhash().
-        #   DUO130: Flake8 is using this.
-        return hashlib.md5(str(rnd + micro_second).encode("utf-8")).hexdigest()  # noqa: S324 DUO130 RUF100 # nosec
+        # Reason: Switching to SHA256 would break protocol compatibility because radiko.jp's JavaScript
+        # uses MD5_hexhash() for this non-cryptographic UID (lsid parameter); MD5 is not used for
+        # security here:
+        # - semgrep-rules: insecure-hash-algorithms-md5.yaml (official rule source)
+        #   https://raw.githubusercontent.com/semgrep/semgrep-rules/develop/python/lang/security/insecure-hash-algorithms-md5.yaml
+        return hashlib.md5(str(rnd + micro_second).encode("utf-8")).hexdigest()  # noqa: S324 DUO130 RUF100 # nosec # nosemgrep: python.lang.security.insecure-hash-algorithms-md5.insecure-hash-algorithm-md5
 
 
 class TimeFree30DayMasterPlaylistRequest(MasterPlaylistRequest):
@@ -141,6 +144,9 @@ class TimeFree30DayMasterPlaylistRequest(MasterPlaylistRequest):
         now = datetime.datetime.now(tz=TimeFree30DayMasterPlaylistRequest.JST)
         start = datetime.datetime(1970, 1, 1, tzinfo=TimeFree30DayMasterPlaylistRequest.JST)
         micro_second = datetime.timedelta.total_seconds(now - start) * 1000
-        # Reason: 2023-02-06 Javascript in radiko.jp still use MD5_hexhash().
-        #   DUO130: Flake8 is using this.
-        return hashlib.md5(str(rnd + micro_second).encode("utf-8")).hexdigest()  # noqa: S324 DUO130 RUF100 # nosec
+        # Reason: Switching to SHA256 would break protocol compatibility because radiko.jp's JavaScript
+        # uses MD5_hexhash() for this non-cryptographic UID (lsid parameter); MD5 is not used for
+        # security here:
+        # - semgrep-rules: insecure-hash-algorithms-md5.yaml (official rule source)
+        #   https://raw.githubusercontent.com/semgrep/semgrep-rules/develop/python/lang/security/insecure-hash-algorithms-md5.yaml
+        return hashlib.md5(str(rnd + micro_second).encode("utf-8")).hexdigest()  # noqa: S324 DUO130 RUF100 # nosec # nosemgrep: python.lang.security.insecure-hash-algorithms-md5.insecure-hash-algorithm-md5

--- a/radikoplaylist/playlist_create_url_getter.py
+++ b/radikoplaylist/playlist_create_url_getter.py
@@ -6,7 +6,6 @@ from abc import ABC
 from abc import abstractmethod
 from typing import TYPE_CHECKING
 from typing import Generic
-from typing import Mapping
 from typing import TypeVar
 
 from defusedxml import ElementTree
@@ -16,6 +15,8 @@ from radikoplaylist.exceptions import NoAvailableUrlError
 from radikoplaylist.requester import Requester
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     # - defusedxml lacks an Element class · Issue #48 · tiran/defusedxml
     #   https://github.com/tiran/defusedxml/issues/48#issuecomment-1511284750
     from xml.etree.ElementTree import Element  # nosec B405

--- a/radikoplaylist/playlist_create_url_getter.py
+++ b/radikoplaylist/playlist_create_url_getter.py
@@ -76,7 +76,7 @@ class PlaylistCreateUrlGetter(Generic[TypeVarHost]):
 
     @classmethod
     def get_playlist_create_url(cls, string_xml: str) -> str:
-        """Parses XML and extract target URL to create playlist."""
+        """Parse XML and extract target URL to create playlist."""
         root = ElementTree.fromstring(string_xml, forbid_dtd=True)
         list_url = root.findall(".//url[@areafree='1']")
         list_playlist_create_url = [
@@ -86,7 +86,7 @@ class PlaylistCreateUrlGetter(Generic[TypeVarHost]):
 
     @classmethod
     def strip_playlist_create_url(cls, url: Element) -> str:
-        """Strips playlist create URL."""
+        """Strip playlist create URL."""
         element = url.find("./playlist_create_url")
         if element is None:
             msg = "playlist_create_url element not found"
@@ -98,7 +98,7 @@ class PlaylistCreateUrlGetter(Generic[TypeVarHost]):
 
     @classmethod
     def filter_playlist_create_url(cls, list_playlist_create_url: list[str]) -> str:
-        """Filters playlist create URL.
+        """Filter playlist create URL.
 
         This method is the part divided from get_playlist_create_url() since radon grades unified method as B.
         """

--- a/radikoplaylist/requester.py
+++ b/radikoplaylist/requester.py
@@ -5,15 +5,15 @@ from __future__ import annotations
 from logging import getLogger
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from collections.abc import Mapping
-
 import requests
 from requests import Response
 from requests import Timeout
 
 from radikoplaylist.exceptions import BadHttpStatusCodeError
 from radikoplaylist.exceptions import HttpRequestTimeoutError
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 
 class Requester:

--- a/radikoplaylist/requester.py
+++ b/radikoplaylist/requester.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from logging import getLogger
-from typing import Mapping
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 import requests
 from requests import Response

--- a/tests/test_playlist_create_url_getter.py
+++ b/tests/test_playlist_create_url_getter.py
@@ -17,7 +17,12 @@ if TYPE_CHECKING:
     #   https://github.com/tiran/defusedxml/issues/48#issuecomment-1511284750
     from xml.etree.ElementTree import Element  # nosec B405
 
-
+HTML_PLAYLIST_CREATE_URL = dedent("""\
+    <?xml version="1.0"?>
+    <data>
+        <playlist_create_url>https://radiko.jp/v2/api/ts/playlist.m3u8</playlist_create_url>
+    </data>
+""")
 HTML_PLAYLIST_CREATE_URL_ELEMENT_NOT_FOUND = dedent("""\
     <?xml version="1.0"?>
     <data>
@@ -71,14 +76,7 @@ class TestPlaylistCreateUrlGetter:
 
     def test_strip_playlist_create_url(self) -> None:
         """Method strip_playlist_create_url should return appropriate URL."""
-        element_url = ElementTree.fromstring(
-            """<?xml version="1.0"?>
-            <data>
-                <playlist_create_url>https://radiko.jp/v2/api/ts/playlist.m3u8</playlist_create_url>"
-            </data>
-            """,
-            forbid_dtd=True,
-        )
+        element_url = ElementTree.fromstring(HTML_PLAYLIST_CREATE_URL, forbid_dtd=True)
         url = LivePlaylistCreateUrlGetter.strip_playlist_create_url(element_url)
         assert url == "https://radiko.jp/v2/api/ts/playlist.m3u8"
 

--- a/tests/test_playlist_create_url_getter.py
+++ b/tests/test_playlist_create_url_getter.py
@@ -76,8 +76,7 @@ class TestPlaylistCreateUrlGetter:
             <data>
                 <playlist_create_url>https://radiko.jp/v2/api/ts/playlist.m3u8</playlist_create_url>"
             </data>
-            """
-               ,
+            """,
             forbid_dtd=True,
         )
         url = LivePlaylistCreateUrlGetter.strip_playlist_create_url(element_url)

--- a/tests/test_playlist_create_url_getter.py
+++ b/tests/test_playlist_create_url_getter.py
@@ -1,5 +1,6 @@
 """Tests for radikoplaylist.playlist_create_url_getter."""
 
+from textwrap import dedent
 from typing import TYPE_CHECKING
 
 import pytest
@@ -15,6 +16,19 @@ if TYPE_CHECKING:
     # - defusedxml lacks an Element class · Issue #48 · tiran/defusedxml
     #   https://github.com/tiran/defusedxml/issues/48#issuecomment-1511284750
     from xml.etree.ElementTree import Element  # nosec B405
+
+
+HTML_PLAYLIST_CREATE_URL_ELEMENT_NOT_FOUND = dedent("""\
+    <?xml version="1.0"?>
+    <data>
+    </data>
+""")
+HTML_PLAYLIST_CREATE_URL_ELEMENT_TEXT_IS_NONE = dedent("""\
+    <?xml version="1.0"?>
+    <data>
+        <playlist_create_url></playlist_create_url>
+    </data>
+""")
 
 
 class TestPlaylistCreateUrlGetter:
@@ -62,7 +76,8 @@ class TestPlaylistCreateUrlGetter:
             <data>
                 <playlist_create_url>https://radiko.jp/v2/api/ts/playlist.m3u8</playlist_create_url>"
             </data>
-            """,
+            """
+               ,
             forbid_dtd=True,
         )
         url = LivePlaylistCreateUrlGetter.strip_playlist_create_url(element_url)
@@ -72,24 +87,11 @@ class TestPlaylistCreateUrlGetter:
         ("element_url", "error_message"),
         [
             (
-                ElementTree.fromstring(
-                    """<?xml version="1.0"?>
-                    <data>
-                    </data>
-                    """,
-                    forbid_dtd=True,
-                ),
+                ElementTree.fromstring(HTML_PLAYLIST_CREATE_URL_ELEMENT_NOT_FOUND, forbid_dtd=True),
                 "playlist_create_url element not found",
             ),
             (
-                ElementTree.fromstring(
-                    """<?xml version="1.0"?>
-                    <data>
-                        <playlist_create_url></playlist_create_url>"
-                    </data>
-                    """,
-                    forbid_dtd=True,
-                ),
+                ElementTree.fromstring(HTML_PLAYLIST_CREATE_URL_ELEMENT_TEXT_IS_NONE, forbid_dtd=True),
                 "playlist_create_url text is None",
             ),
         ],

--- a/tests/testlibraries/expected_url.py
+++ b/tests/testlibraries/expected_url.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 from dataclasses import asdict
 from dataclasses import dataclass
-from typing import Iterator
-from typing import Pattern
+from typing import TYPE_CHECKING
 from urllib.parse import ParseResult
 from urllib.parse import parse_qs
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from re import Pattern
 
 
 @dataclass

--- a/tests/testlibraries/expected_url.py
+++ b/tests/testlibraries/expected_url.py
@@ -24,7 +24,7 @@ class ExpectedUrlProperties:
         return iter(asdict(self).values())
 
     def assert_parse_result_url(self, parse_result_url: ParseResult) -> None:
-        """Checks."""
+        """Check."""
         list_actual = [
             parse_result_url.scheme,
             parse_result_url.netloc,
@@ -49,12 +49,11 @@ class ExpectedUrl:
         self.query = query
 
     def check(self, parse_result_url: ParseResult) -> None:
-        """Checks."""
         self.expected_url_properties.assert_parse_result_url(parse_result_url)
         self.check_url_query(parse_result_url.query)
 
     def check_url_query(self, query: str) -> None:
-        """Checks URL query."""
+        """Check URL query."""
         parsed_result_query = parse_qs(query)
         for key, expected in self.query.items():
             actual = parsed_result_query[key][0]


### PR DESCRIPTION
- Add Python 3.14 to supported versions: PyPI classifiers, CI test matrix, and Dockerfile base image
- Migrate all GitHub Actions reusable workflow references from `@main` to pinned commit SHAs for supply-chain security; add top-level `permissions` blocks to each workflow
- Consolidate dev dependencies: replace ~15 individually listed linting tools with `invokelint[basic]>=0.19.0` bundle; bump `semgrep>=0.87.0` to fix build failure under Python 3.14
- Modernize type imports: move `Mapping`, `Iterator`, and `Pattern` from `typing` to `collections.abc` under `TYPE_CHECKING`
- Fix docstrings to imperative mood ("Get" not "Gets"); remove trivial one-line docstrings from short methods
- Refactor test XML fixtures from inline strings to module-level `dedent()` constants for readability
- Mount `~/.claude` into the devcontainer so Claude Code configuration is shared with the container
